### PR TITLE
Add JSONP support (untested).

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -60,10 +60,18 @@ class FormController < ApplicationController
       FormMailer.form_submission(@form, params).deliver_now
       respond_to do |format|
         format.json do
-          render :json => {
-            :status => :ok,
-            :message => 'form submitted'
-          }
+          if params[:callback]
+            render :json => {
+                :status => :ok,
+                :message => 'form submitted'
+            },
+            :callback => params[:callback]
+          else
+            render :json => {
+              :status => :ok,
+              :message => 'form submitted'
+            }
+          end
         end
         format.html { redirect_to @form.success_url }
       end


### PR DESCRIPTION
JSONP is a way of sending JSON cross-domain.  Since I don't actually have a ruby environment set up yet, I have not tested this change.  A Rubyist should be able to tell if the changes are kosher with a simple inspection though.
